### PR TITLE
fix(security): reject prototype-polluting patch paths

### DIFF
--- a/lib/__tests__/proxyReducer.test.ts
+++ b/lib/__tests__/proxyReducer.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { afterEach, describe, it, expect } from 'vitest';
 import {
 	applyPatch,
 	immerProxyStoreReducer,
@@ -119,6 +119,104 @@ describe('immerProxyStoreReducer', () => {
 			);
 
 			expect(result).toEqual({ baz: 'qux' });
+		});
+	});
+	describe('APPLY_PATCH_ACTION prototype pollution', () => {
+		afterEach(() => {
+			// Undo pollution so a failure here cannot cascade into other tests
+			delete (Object.prototype as Record<string, unknown>).polluted;
+		});
+
+		it('should not pollute Object.prototype through a __proto__ path', () => {
+			const state: Record<string, unknown> & ProxyState = {
+				foo: 'bar',
+				[SYNC_KEY]: true
+			};
+
+			immerProxyStoreReducer(
+				state,
+				applyPatch([{ op: 'add', path: ['__proto__', 'polluted'], value: 'yes' }])
+			);
+
+			expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+			expect(Object.prototype).not.toHaveProperty('polluted');
+		});
+
+		it('should not pollute Object.prototype through a constructor.prototype path', () => {
+			const state: Record<string, unknown> & ProxyState = {
+				foo: 'bar',
+				[SYNC_KEY]: true
+			};
+
+			immerProxyStoreReducer(
+				state,
+				applyPatch([
+					{
+						op: 'add',
+						path: ['constructor', 'prototype', 'polluted'],
+						value: 'yes'
+					}
+				])
+			);
+
+			expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+			expect(Object.prototype).not.toHaveProperty('polluted');
+		});
+
+		it('should not delete inherited properties through a __proto__ path', () => {
+			(Object.prototype as Record<string, unknown>).polluted = 'preexisting';
+
+			const state: Record<string, unknown> & ProxyState = {
+				foo: 'bar',
+				[SYNC_KEY]: true
+			};
+
+			immerProxyStoreReducer(
+				state,
+				applyPatch([{ op: 'remove', path: ['__proto__', 'polluted'] }])
+			);
+
+			expect(Object.prototype).toHaveProperty('polluted');
+		});
+
+		it('should still apply legitimate patches', () => {
+			const state: Record<string, unknown> & ProxyState = {
+				foo: 'bar',
+				nested: { count: 1 },
+				list: [1, 2, 3],
+				[SYNC_KEY]: true
+			};
+
+			const result = immerProxyStoreReducer(
+				state,
+				applyPatch([
+					{ op: 'replace', path: ['foo'], value: 'baz' },
+					{ op: 'add', path: ['nested', 'added'], value: true },
+					{ op: 'remove', path: ['list', 1] }
+				])
+			);
+
+			expect(result.foo).toBe('baz');
+			expect(result.nested).toEqual({ count: 1, added: true });
+			expect(result.list).toEqual([1, 3]);
+		});
+
+		it('should drop only the unsafe patch and keep the rest', () => {
+			const state: Record<string, unknown> & ProxyState = {
+				foo: 'bar',
+				[SYNC_KEY]: true
+			};
+
+			const result = immerProxyStoreReducer(
+				state,
+				applyPatch([
+					{ op: 'add', path: ['__proto__', 'polluted'], value: 'yes' },
+					{ op: 'replace', path: ['foo'], value: 'baz' }
+				])
+			);
+
+			expect(result.foo).toBe('baz');
+			expect(({} as Record<string, unknown>).polluted).toBeUndefined();
 		});
 	});
 });

--- a/lib/proxyStore/proxyReducer.ts
+++ b/lib/proxyStore/proxyReducer.ts
@@ -7,6 +7,14 @@ import { SYNC_KEY } from '../constants';
 export const APPLY_PATCH_ACTION = 'proxyStore/applyPatch' as const;
 export const SYNC_GLOBAL_ACTION = 'proxyStore/syncGlobal' as const;
 
+// Patches arrive from another process over the port/IPC channel, so every path
+// segment is untrusted input. Walking or writing through these keys would reach
+// Object.prototype and let a sender tamper with every object in the app.
+const UNSAFE_PATH_KEYS = new Set(['__proto__', 'prototype', 'constructor']);
+
+const isSafePath = (path: (string | number)[]): boolean =>
+	path.every((key) => !UNSAFE_PATH_KEYS.has(String(key)));
+
 export const applyPatch = (patches: Patch[]) => ({
 	type: APPLY_PATCH_ACTION,
 	payload: patches
@@ -53,12 +61,20 @@ export const immerProxyStoreReducer = <T>(
 
 				patches.forEach((patch) => {
 					const { op, path, value } = patch;
+
+					if (path.length === 0 || !isSafePath(path)) {
+						return;
+					}
 					// eslint-disable-next-line @typescript-eslint/no-explicit-any
 					let target: any = draft;
 
 					// Traverse the path except for the last key
 					for (let i = 0; i < path.length - 1; i++) {
 						target = target[path[i] as keyof typeof target];
+
+						if (target === null || typeof target !== 'object') {
+							return;
+						}
 					}
 
 					const lastKey = path[path.length - 1] as keyof typeof target;


### PR DESCRIPTION
Patches reach the proxy store from another process over the port/IPC channel, so every path segment is untrusted input. A patch with a path of ['__proto__', 'x'] or ['constructor', 'prototype', 'x'] traversed into the prototype chain and assigned through it, polluting Object.prototype for the whole app (CodeQL js/prototype-polluting-assignment).

Unsafe patches are now dropped individually, so legitimate patches in the same batch still apply. Traversal also bails out when an intermediate segment is not an object instead of throwing on a null deref.